### PR TITLE
Various fixes

### DIFF
--- a/cmpreqs/compare_requirements.py
+++ b/cmpreqs/compare_requirements.py
@@ -8,7 +8,7 @@ def get_version(line):
     else:
         d = line.split('==')
         if len(d) > 1:
-            return d[1]
+            return d[1].split('#')[0].strip()
         else:
             return
 

--- a/cmpreqs/compare_requirements.py
+++ b/cmpreqs/compare_requirements.py
@@ -17,7 +17,7 @@ def get_package_name(line):
     if 'git+' in line or 'hg+' in line:
         return line.split('#egg=')[1]
     else:
-        return line.split('==')[0]
+        return line.split('==')[0].lower()
     
     
 def get_requirements(indata):


### PR DESCRIPTION
- Fix parsing versions which are followed by a comment, e.g.: Django==1.11.1 # mycomment
- Make package names case insensitive to match 'Django' with 'django'